### PR TITLE
Add support for Samsung ARTIK boards (520, 710, 1020) and ARTIK SDK

### DIFF
--- a/boards/artik_1020.json
+++ b/boards/artik_1020.json
@@ -1,0 +1,17 @@
+{
+  "build": {
+    "extra_flags": "",
+    "f_cpu": "1500000000L",
+    "mcu": "exynos5422"
+  },
+  "frameworks": [
+    "artik-sdk"
+  ],
+  "name": "Samsung ARTIK 1020",
+  "upload": {
+    "maximum_ram_size": 2147483648,
+    "maximum_size": 2147483648
+  },
+  "url": "https://www.artik.io",
+  "vendor": "Samsung"
+}

--- a/boards/artik_520.json
+++ b/boards/artik_520.json
@@ -1,0 +1,17 @@
+{
+  "build": {
+    "extra_flags": "",
+    "f_cpu": "1000000000L",
+    "mcu": "exynos3250"
+  },
+  "frameworks": [
+    "artik-sdk"
+  ],
+  "name": "Samsung ARTIK 520",
+  "upload": {
+    "maximum_ram_size": 536870912,
+    "maximum_size": 536870912
+  },
+  "url": "https://www.artik.io",
+  "vendor": "Samsung"
+}

--- a/boards/artik_710.json
+++ b/boards/artik_710.json
@@ -1,0 +1,17 @@
+{
+  "build": {
+    "extra_flags": "",
+    "f_cpu": "1400000000L",
+    "mcu": "s5p6818"
+  },
+  "frameworks": [
+    "artik-sdk"
+  ],
+  "name": "Samsung ARTIK 710",
+  "upload": {
+    "maximum_ram_size": 1073741824,
+    "maximum_size": 1073741824
+  },
+  "url": "https://www.artik.io",
+  "vendor": "Samsung"
+}

--- a/builder/frameworks/artik-sdk.py
+++ b/builder/frameworks/artik-sdk.py
@@ -1,0 +1,60 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+ARTIK SDK
+
+ARTIK SDK is a C/C++ SDK targeting Samsung ARTIK platforms. It exposes
+a set of APIs to ease up development of applications. These APIs cover
+hardware buses such as GPIO, SPI, I2C, UART, connectivity links
+like Wi-Fi, Bluetooth, Zigbee, and network protocols such as HTTP, Websockets,
+MQTT, and others.
+
+http://www.artik.io
+"""
+
+from os.path import join
+
+from SCons.Script import DefaultEnvironment
+
+env = DefaultEnvironment()
+
+env.Replace(
+    CPPFLAGS=[
+        "-O2",
+        "-Wformat=2",
+        "-Wall",
+        "-Winline",
+        "-pipe",
+        "-fPIC"
+    ],
+
+    LIBS=[
+        "artik-sdk-base"
+    ]
+)
+
+env.Append(
+    CPPPATH=[
+        "/usr/include/artik/base",
+        "/usr/include/artik/bluetooth",
+        "/usr/include/artik/connectivity",
+        "/usr/include/artik/lwm2m",
+        "/usr/include/artik/media",
+        "/usr/include/artik/sensor",
+        "/usr/include/artik/systemio",
+        "/usr/include/artik/wifi",
+        "/usr/include/artik/zigbee"
+    ]
+)

--- a/platform.json
+++ b/platform.json
@@ -22,6 +22,10 @@
     "wiringpi": {
       "package": "framework-wiringpi",
       "script": "builder/frameworks/wiringpi.py"
+    },
+    "artik-sdk": {
+      "package": "framework-artik-sdk",
+      "script": "builder/frameworks/artik-sdk.py"
     }
   },
   "packages": {
@@ -33,6 +37,11 @@
       "type": "framework",
       "optional": true,
       "version": "~1.232.0"
+    },
+    "framework-artik-sdk": {
+      "type": "framework",
+      "optional": true,
+      "version": "1.0.2"
     }
   }
 }


### PR DESCRIPTION
First shot at ARTIK boards/SDK integration. Still need to push "framework-artik-sdk" package to a public repo.