### PR TITLE
Update Samsung ARTIK support

### DIFF
--- a/boards/artik_1020.json
+++ b/boards/artik_1020.json
@@ -10,7 +10,7 @@
   "name": "Samsung ARTIK 1020",
   "upload": {
     "maximum_ram_size": 2147483648,
-    "maximum_size": 2147483648
+    "maximum_size": 17179869184
   },
   "url": "https://www.artik.io",
   "vendor": "Samsung"

--- a/boards/artik_520.json
+++ b/boards/artik_520.json
@@ -10,7 +10,7 @@
   "name": "Samsung ARTIK 520",
   "upload": {
     "maximum_ram_size": 536870912,
-    "maximum_size": 536870912
+    "maximum_size": 4294967296
   },
   "url": "https://www.artik.io",
   "vendor": "Samsung"

--- a/boards/artik_530.json
+++ b/boards/artik_530.json
@@ -1,15 +1,15 @@
 {
   "build": {
     "extra_flags": "",
-    "f_cpu": "1400000000L",
-    "mcu": "s5p6818"
+    "f_cpu": "1200000000L",
+    "mcu": "s5p4418"
   },
   "frameworks": [
     "artik-sdk"
   ],
-  "name": "Samsung ARTIK 710",
+  "name": "Samsung ARTIK 530",
   "upload": {
-    "maximum_ram_size": 1073741824,
+    "maximum_ram_size": 536870912,
     "maximum_size": 4294967296
   },
   "url": "https://www.artik.io",

--- a/platform.json
+++ b/platform.json
@@ -42,7 +42,7 @@
     "framework-artik-sdk": {
       "type": "framework",
       "optional": true,
-      "version": "~1.0.0"
+      "version": "~1.1.0"
     }
   }
 }


### PR DESCRIPTION
The ARTIK family just got a new member: https://www.artik.io/blog/2017/02/introducing-samsung-artik-530/. Also the ARTIK SDK has been updated to version 1.1.3.

This pull request adds support for all these very good news.