### PR TITLE
Update framework-artik-sdk to version 1.2.x

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -41,8 +41,7 @@
     },
     "framework-artik-sdk": {
       "type": "framework",
-      "optional": true,
-      "version": "~1.1.0"
+      "optional": true
     }
   }
 }


### PR DESCRIPTION
New version of the ARTIK SDK has been released, making it available in framework-artik-sdk. Full API documentation available here: https://developer.artik.io/documentation/api/